### PR TITLE
Allow environment variables to be used in lieu of command line flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,11 @@
-FROM golang:1.11 AS builder
-
+FROM golang:1.12 AS builder
 
 WORKDIR /go/src/github.com/claranet/rubrik-exporter
 COPY . .
-RUN go get
-RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w'
+RUN go get \
+    && CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w'
 
-#ENTRYPOINT [ "/go/src/github.com/claranet/rubrik-exporter/rubrik-exporter" ]
-
-#------------------------
-
-# Final image.
-FROM quay.io/prometheus/busybox:latest
-#FROM alpine
-LABEL maintainer "Martin Weber <martin.weber@de.clara.net>"
-WORKDIR /usr/local/bin/
-COPY --from=builder /go/src/github.com/claranet/rubrik-exporter/rubrik-exporter /usr/local/bin/
+FROM scratch
+COPY --from=builder /go/src/github.com/claranet/rubrik-exporter/rubrik-exporter /
 EXPOSE 9477
-ENTRYPOINT [ "/usr/local/bin/rubrik-exporter" ]
-CMD [ ]
+ENTRYPOINT [ "/rubrik-exporter" ]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Commandline Options
         -rubrik.username string
                 Zerto API User
 
+Environment variables can be used in lieu of commandline flags by uppercasing the
+entire flag (e.g. you can ommit -rubrik.password if RUBRIK.PASSWORD is set)
+
 Easy to use
 =============
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.7'
+
+services:
+  rubrik-exporter:
+    image: claranet/rubrik-exporter
+    build: .
+    ports:
+      - '9477:9477'
+    environment:
+      RUBRIK.URL: https://rubrik.example.com
+      RUBRIK.USERNAME: prometheus
+      RUBRIK.PASSWORD: super_secret_password

--- a/main.go
+++ b/main.go
@@ -11,11 +11,10 @@
 package main
 
 import (
-	"flag"
 	"net/http"
 
 	"github.com/claranet/rubrik-exporter/rubrik"
-
+	"github.com/namsral/flag"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/log"
 )


### PR DESCRIPTION
When running in Kubernetes or in a Docker cluster, the command line flags can't be stored outside of the manifest file. Since many companies store the manifest files in git, we don't want to keep secrets there.

The [github.com/namsral/flag](https://github.com/namsral/flag) go package is a drop in replacement for the flag package so that environment variables are automatically checked in the absence of a command line flag.

While working on this a bit, I also fixed up the Dockerfile a bit by upgrading the version of Go and removing a few ignored lines.