### PR TITLE
update go 1.15, fix prometheus build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11 AS builder
+FROM golang:1.15 AS builder
 
 
 WORKDIR /go/src/github.com/claranet/rubrik-exporter

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/claranet/rubrik-exporter/rubrik"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/log"
 )
 
@@ -42,7 +43,7 @@ func main() {
 	prometheus.MustRegister(NewArchiveLocation())
 	prometheus.MustRegister(NewManagedVolume())
 
-	http.Handle("/metrics", prometheus.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html><head><title>Rubrik Exporter</title></head><body><h1>Rubrik Exporter</h1><p><a href="/metrics">Metrics</a></p></body></html>`))
 	})


### PR DESCRIPTION
Appears like Prometheus golang library has changed.
This resolves the below message.
````
Step 4/12 : RUN go get
 ---> Running in b0da2ab6ebb3
# github.com/claranet/rubrik-exporter
./main.go:45:26: undefined: prometheus.Handler
````